### PR TITLE
[UX] Make level type more explicit

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -13,7 +13,7 @@ const Dashboard = () => {
   const fetchData = () => {
     GitlabLintHttpClient("GET_ALL", { entity: "stats" })
       .then((data) => {
-        setData(data);
+        setData(data.data);
       })
       .catch((err) => console.error(err));
   };

--- a/src/levels/Levels.js
+++ b/src/levels/Levels.js
@@ -35,7 +35,7 @@ const Levels = () => {
   const fetchData = () => {
     GitlabLintHttpClient("GET_ALL", { entity: "levels" })
       .then((data) => {
-        setData(data);
+        setData(data.data);
       })
       .catch((err) => console.error(err));
   };

--- a/src/projects/Project.js
+++ b/src/projects/Project.js
@@ -24,7 +24,7 @@ const Project = () => {
   const fetchData = () => {
     GitlabLintHttpClient("GET_ONE", { entity: "projects", id: id })
       .then((data) => {
-        setData(data);
+        setData(data.data);
       })
       .catch((err) => console.error(err));
   };

--- a/src/projects/Projects.js
+++ b/src/projects/Projects.js
@@ -47,8 +47,8 @@ const useStyles = makeStyles((theme) => ({
 const Projects = () => {
   const classes = useStyles();
 
-  const [page, setPage] = React.useState(1);
-  const [searchInput, setSearchInput] = React.useState("");
+  const [page, setPage] = useState(1);
+  const [searchInput, setSearchInput] = useState("");
   const handleChange = (event, value) => {
     setPage(value);
     fetchData({ query: { page: value, q: searchInput } });
@@ -62,10 +62,12 @@ const Projects = () => {
     debouncedSearch(value);
   };
   const [rows, setData] = useState({});
+  const [meta, setMeta] = useState({});
   const fetchData = ({ query }) => {
     GitlabLintHttpClient("GET_ALL", { entity: "projects", query: query })
       .then((data) => {
-        setData(data);
+        setData(data.data);
+        setMeta(data.meta);
       })
       .catch((err) => console.error(err));
   };
@@ -123,7 +125,7 @@ const Projects = () => {
         <Pagination
           boundaryCount={2}
           color="primary"
-          count={323}
+          count={meta.totalOfPages}
           onChange={handleChange}
           page={page}
           siblingCount={2}

--- a/src/rules/Rule.js
+++ b/src/rules/Rule.js
@@ -65,7 +65,7 @@ const Rule = () => {
   const fetchData = () => {
     GitlabLintHttpClient("GET_ONE", { entity: "rules", id: id })
       .then((data) => {
-        setData(data);
+        setData(data.data);
       })
       .catch((err) => console.error(err));
   };

--- a/src/rules/Rule.js
+++ b/src/rules/Rule.js
@@ -93,9 +93,6 @@ const Rule = () => {
       {rows.rule.description && (
         <p className={classes.ruleDescription}>{rows.rule.description}</p>
       )}
-      <p>
-        <strong>Level</strong>: {rows.rule.level}
-      </p>
       <Box pt={2} pb={2}>
         <Divider />
       </Box>

--- a/src/rules/RuleTitle.js
+++ b/src/rules/RuleTitle.js
@@ -5,6 +5,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
 import { Typography } from "@material-ui/core";
+import titleCase from "../utils"
 
 import levelsStyles from "../theme";
 
@@ -14,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: size === "normal" ? 32 : 16,
     marginRight: 8,
     padding: size === "normal" ? "8px 24px" : "4px 8px",
-    minWidth: 32,
+    minWidth: 100,
     textAlign: "center",
     color: "#fff",
   }),
@@ -37,7 +38,7 @@ const RuleTitle = ({ rule, size }) => {
   return (
     <div className={classes.root}>
       <span className={`${classes.title} ${classes[level]}`}>
-        {level.charAt(0).toUpperCase()}
+        {titleCase(level)}
       </span>
       <Typography variant={titleVariant}>{ruleId}</Typography>
     </div>

--- a/src/rules/Rules.js
+++ b/src/rules/Rules.js
@@ -31,7 +31,7 @@ const Rules = () => {
   const fetchData = () => {
     GitlabLintHttpClient("GET_ALL", { entity: "rules" })
       .then((data) => {
-        setData(data);
+        setData(data.data);
       })
       .catch((err) => console.error(err));
   };

--- a/src/rules/Rules.js
+++ b/src/rules/Rules.js
@@ -22,6 +22,9 @@ const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 345,
   },
+  title: {
+    color: "#fff",
+  },
   ...levelsStyles,
 }));
 
@@ -56,7 +59,7 @@ const Rules = () => {
             <Grid item key={row.ruleId} xs={12} sm={6} md={4}>
               <Card className={classes.root}>
                 <CardActionArea href={`/rules/${row.ruleId}`}>
-                  <CardHeader className={classes[row.level]} />
+                  <CardHeader className={classes[row.level]} classes={{title: classes["title"]}} title={row.level} />
                   <CardContent>
                     <Typography gutterBottom variant="h5" component="h2">
                       {row.name}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+const titleCase = (str) => {
+    return str.toLowerCase().split(' ').map(function(word) {
+        return (word.charAt(0).toUpperCase() + word.slice(1));
+    }).join(' ');
+};
+
+export default titleCase;


### PR DESCRIPTION
With just the first letter of the level, one might get confused (P means Panic? Pedantic?)

This is my proposal to make it more explicit without breaking visuals.

Project page:
![Screenshot_20210514_221958](https://user-images.githubusercontent.com/5046551/118335139-63cfb800-b4e5-11eb-9ea4-ae02674f86b2.png)

Rules List:
![Screenshot_20210514_222259](https://user-images.githubusercontent.com/5046551/118335176-70eca700-b4e5-11eb-931e-9b40a0cc6291.png)

Levels list (unchanged):
![Screenshot_20210514_222318](https://user-images.githubusercontent.com/5046551/118335190-7813b500-b4e5-11eb-9348-ba837feb54e6.png)



