### PR TITLE
Improve link handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gitlab-lint-react",
   "version": "0.1.0",
+  "homepage": ".",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.12.3",

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@
 // Licensed under the BSD 3-Clause License
 
 import React, { useEffect, useReducer, useMemo } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { HashRouter as Router, Link, Route, Switch } from "react-router-dom";
 import {
   createTheme,
   makeStyles,
@@ -109,24 +109,24 @@ const App = () => {
             <Container maxWidth="lg">
               <Toolbar>
                 <Typography
-                  component="a"
+                  component={Link}
                   color="inherit"
                   variant="h6"
                   className={classes.title}
-                  href="/"
+                  to="/"
                 >
                   gitlab-lint
                 </Typography>
-                <Button color="inherit" href="/rules">
+                <Button component={Link} color="inherit" to="/rules">
                   Rules
                 </Button>
-                <Button color="inherit" href="/projects">
+                <Button component={Link} color="inherit" to="/projects">
                   Projects
                 </Button>
-                <Button color="inherit" href="/levels">
+                <Button component={Link} color="inherit" to="/levels">
                   Levels
                 </Button>
-                <Button color="inherit" href="/about">
+                <Button component={Link} color="inherit" to="/about">
                   About
                 </Button>
                 <IconButton

--- a/src/projects/Project.js
+++ b/src/projects/Project.js
@@ -2,7 +2,7 @@
 // Licensed under the BSD 3-Clause License
 
 import React, { useState, useEffect, useCallback } from "react";
-import { useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 import {
   Box,
   Breadcrumbs,
@@ -58,7 +58,7 @@ const Project = () => {
   return (
     <React.Fragment>
       <Breadcrumbs aria-label="breadcrumb">
-        <Link color="inherit" href="/projects">
+        <Link component={RouterLink} color="inherit" to="/projects">
           Projects
         </Link>
         <Typography color="textPrimary">
@@ -99,8 +99,8 @@ const Project = () => {
             <ListItem
               key={rule.ruleId}
               button
-              component="a"
-              href={`/rules/${rule.ruleId}`}
+              component={RouterLink}
+              to={`/rules/${rule.ruleId}`}
             >
               <RuleTitle rule={rule} size="small" />
             </ListItem>

--- a/src/projects/Projects.js
+++ b/src/projects/Projects.js
@@ -2,6 +2,7 @@
 // Licensed under the BSD 3-Clause License
 
 import React, { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Pagination from "@material-ui/lab/Pagination";
 import {
@@ -99,8 +100,8 @@ const Projects = () => {
           return (
             <ListItem
               button
-              component="a"
-              href={`/projects/${row.id}`}
+              component={Link}
+              to={`/projects/${row.id}`}
               key={row.id}
             >
               <ListItemText primary={row.path_with_namespace} />

--- a/src/rules/Rule.js
+++ b/src/rules/Rule.js
@@ -3,7 +3,8 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import { useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
+
 import {
   Box,
   Breadcrumbs,
@@ -47,8 +48,8 @@ const RuleProjects = ({ projects }) => {
             <ListItem
               key={row.projectId}
               button
-              component="a"
-              href={`/projects/${row.projectId}`}
+              component={RouterLink}
+              to={`/projects/${row.projectId}`}
             >
               <ListItemText primary={row.pathWithNamespace} />
             </ListItem>
@@ -82,7 +83,7 @@ const Rule = () => {
   return (
     <React.Fragment>
       <Breadcrumbs aria-label="breadcrumb">
-        <Link color="inherit" href="/rules">
+        <Link component={RouterLink} color="inherit" to="/rules">
           Rules
         </Link>
         <Typography color="textPrimary">{rows.rule.ruleId}</Typography>

--- a/src/rules/Rules.js
+++ b/src/rules/Rules.js
@@ -2,6 +2,7 @@
 // Licensed under the BSD 3-Clause License
 
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import {
   Button,
@@ -58,7 +59,7 @@ const Rules = () => {
           return (
             <Grid item key={row.ruleId} xs={12} sm={6} md={4}>
               <Card className={classes.root}>
-                <CardActionArea href={`/rules/${row.ruleId}`}>
+                <CardActionArea component={Link} to={`rules/${row.ruleId}`}>
                   <CardHeader
                     className={classes[row.level]}
                     classes={{ title: classes["title"] }}
@@ -81,9 +82,10 @@ const Rules = () => {
                 </CardActionArea>
                 <CardActions>
                   <Button
+                    component={Link}
                     size="small"
                     color="secondary"
-                    href={`/rules/${row.ruleId}`}
+                    to={`/rules/${row.ruleId}`}
                   >
                     Show projects
                   </Button>


### PR DESCRIPTION
Links were using href, which is not optimal on a react app (refresh on every click)

As a bonus, it now works with builds served on a different path than root (eg: example.com/gitlab-lint/...)

(in order to fully work with relative paths and static html, I changed from BrowserRouter to HashRouter)