### PR TITLE
feat: Add responsive menu for mobile view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@
 import React, { useEffect, useReducer, useMemo } from "react";
 import { HashRouter as Router, Link, Route, Switch } from "react-router-dom";
 import {
-  createTheme,
+  createMuiTheme,
   makeStyles,
   MuiThemeProvider,
 } from "@material-ui/core/styles";
@@ -18,6 +18,8 @@ import {
   Typography,
 } from "@material-ui/core";
 
+import { Menu, Close } from "@material-ui/icons";
+
 import Dashboard from "./dashboard/Dashboard";
 import NotFound from "./not_found/NotFound";
 import Project from "./projects/Project";
@@ -28,9 +30,69 @@ import Levels from "./levels/Levels";
 import About from "./about/About";
 import { Brightness4, Brightness7 } from "@material-ui/icons";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   title: {
-    flexGrow: 1,
+    minHeight: "56px",
+    lineHeight: "56px",
+    textDecoration: "none",
+  },
+  navLinks: {
+    display: "block",
+
+    [theme.breakpoints.down("xs")]: {
+      display: "none",
+    },
+  },
+  navLinksMobile: {
+    display: "flex",
+    flexDirection: "row",
+    width: "unset",
+
+    [theme.breakpoints.down("xs")]: {
+      flexDirection: "column",
+      width: "100%",
+
+      "& > a": {
+        borderBottom: "1px solid rgba(225, 225, 225, 0.4)",
+        borderRadius: "unset",
+        padding: "10px",
+
+        "&:last-child": {
+          border: "none",
+        },
+      },
+    },
+  },
+  mobileMenuIcon: {
+    display: "none",
+
+    [theme.breakpoints.down("xs")]: {
+      display: "block",
+      background: "none",
+      border: "none",
+      color: "white",
+      cursor: "pointer",
+      position: "absolute",
+      top: "16px",
+      right: "8px",
+    },
+  },
+  dFlex: {
+    display: "flex",
+    justifyContent: "space-between",
+
+    [theme.breakpoints.down("xs")]: {
+      flexDirection: "column",
+    },
+  },
+  IconButton: {
+    order: 1,
+
+    [theme.breakpoints.down("xs")]: {
+      position: "absolute",
+      top: 0,
+      left: "8px",
+    },
   },
   main: {
     paddingTop: 24,
@@ -59,7 +121,7 @@ const App = () => {
 
   const theme = useMemo(
     () =>
-      createTheme({
+      createMuiTheme({
         palette: {
           ...(state.mode === "light"
             ? {
@@ -99,6 +161,23 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem("state", JSON.stringify(state));
   }, [state]);
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  const handleToggleMenu = () => {
+    setIsMobile((isMobile) => !isMobile);
+  };
+
+  function closeMenuOnScroll() {
+    setIsMobile(false);
+  }
+
+  React.useEffect(() => {
+    window.addEventListener("scroll", closeMenuOnScroll);
+
+    return () => {
+      window.removeEventListener("scroll", closeMenuOnScroll);
+    };
+  }, []);
 
   return (
     <Router>
@@ -107,29 +186,9 @@ const App = () => {
           <CssBaseline />
           <AppBar position="static" color="primary">
             <Container maxWidth="lg">
-              <Toolbar>
-                <Typography
-                  component={Link}
-                  color="inherit"
-                  variant="h6"
-                  className={classes.title}
-                  to="/"
-                >
-                  gitlab-lint
-                </Typography>
-                <Button component={Link} color="inherit" to="/rules">
-                  Rules
-                </Button>
-                <Button component={Link} color="inherit" to="/projects">
-                  Projects
-                </Button>
-                <Button component={Link} color="inherit" to="/levels">
-                  Levels
-                </Button>
-                <Button component={Link} color="inherit" to="/about">
-                  About
-                </Button>
+              <Toolbar className={classes.dFlex}>
                 <IconButton
+                  className={classes.IconButton}
                   onClick={() => dispatch({ type: "toggle" })}
                   color="inherit"
                 >
@@ -139,6 +198,42 @@ const App = () => {
                     <Brightness7 />
                   )}
                 </IconButton>
+                <Typography
+                  component="a"
+                  color="inherit"
+                  variant="h6"
+                  className={classes.title}
+                  href="/"
+                >
+                  gitlab-lint
+                </Typography>
+
+                <div
+                  className={
+                    isMobile ? classes.navLinksMobile : classes.navLinks
+                  }
+                  onClick={handleToggleMenu}
+                >
+                  <Button component={Link} color="inherit" to="/rules">
+                    Rules
+                  </Button>
+                  <Button component={Link} color="inherit" to="/projects">
+                    Projects
+                  </Button>
+                  <Button component={Link} color="inherit" to="/levels">
+                    Levels
+                  </Button>
+                  <Button component={Link} color="inherit" to="/about">
+                    About
+                  </Button>
+                </div>
+
+                <button
+                  className={classes.mobileMenuIcon}
+                  onClick={handleToggleMenu}
+                >
+                  {isMobile ? <Close /> : <Menu />}
+                </button>
               </Toolbar>
             </Container>
           </AppBar>


### PR DESCRIPTION
Com esse Pull Request, foram modificados os seguintes pontos:

- Adicionado menu responsivo
-  Título "Gitlab-lint" estava com a área de click indo até o menu de links

Antes do Pull Request:

<img width="460" alt="menu-antigo" src="https://user-images.githubusercontent.com/20020662/139597273-1f8099f0-d412-4a7e-ab0f-141b848014a0.png">

Com o Pull Request:

<img width="453" alt="menu-aberto" src="https://user-images.githubusercontent.com/20020662/139597292-6054dfae-9726-4c82-8aca-e9ced08e0c76.png">

<img width="421" alt="menu-fechado" src="https://user-images.githubusercontent.com/20020662/139597316-9b89b49b-0acc-43da-9d10-f5100f571b63.png">


