### PR TITLE
Adding license into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ make run
 ```
 
 [gitlab-lint]: https://github.com/globocom/gitlab-lint
+
+## License
+gitlab-lint-react is licensed under the [BSD 3-Clause](https://github.com/globocom/gitlab-lint-react/blob/master/LICENSE).


### PR DESCRIPTION
The first point of reading a repository for purposes of understanding is always given by the **README**, and with the public repository, its consumers must be aware of the license, I believe that exposing in the README can be a way for the user not to let the purposes go unnoticed of use of open-source code